### PR TITLE
feat: Enable Alpaca-style conversational dataset training

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,71 @@ The model is trained using microbatch and DDP techniques on 8 GPUs in parallel w
 
 Note: This implementation is for educational purposes only and may not achieve the same performance as the original GPT-2 model.
 
+## Training
 
+### Standard Text Training
+The model can be trained on a plain text file (default: `input.txt`). The `train.py` script handles the training process. You can configure various parameters like batch size, sequence length, learning rate, etc., directly in the script or via command-line arguments (see `python train.py --help`).
+
+To start training with the default settings (single GPU/CPU, using `input.txt`):
+```bash
+python train.py
+```
+
+For Distributed Data Parallel (DDP) training, use `torchrun`:
+```bash
+# Example for 2 GPUs on a single node
+torchrun --nproc_per_node=2 train.py
+```
+
+### Training with Conversational Datasets (Alpaca-style)
+
+This implementation now supports training with conversational datasets formatted in an Alpaca-like style. This is useful for fine-tuning the model for instruction-following or question-answering tasks.
+
+**Dataset Format:**
+
+The dataset should be a JSON or JSONL file. Each entry should be a JSON object containing at least an `"instruction"` and an `"output"` field. An optional `"input"` field can be included for additional context to the instruction.
+
+Example JSON entry:
+```json
+{
+    "instruction": "What is the capital of France?",
+    "input": "",
+    "output": "The capital of France is Paris."
+}
+```
+Or with additional input:
+```json
+{
+    "instruction": "Write a short story about a robot who learns to paint.",
+    "input": "The robot's name is Unit 734.",
+    "output": "Unit 734 had always processed logic, never art. One day, it found a discarded set of paints..."
+}
+```
+A sample file `alpaca_sample.json` is provided in the repository.
+
+**Training Command:**
+
+A convenience script `train_alpaca.sh` is provided to simplify training with Alpaca-style datasets. You can modify the configuration variables at the top of this script:
+
+-   `NPROC_PER_NODE`: Number of GPUs to use (set to 1 for CPU/single GPU).
+-   `DATASET_PATH`: Path to your Alpaca-style JSON/JSONL dataset (defaults to `alpaca_sample.json`).
+-   `BATCH_SIZE`, `SEQ_LEN`, `MAX_STEPS`, `WARMUP_STEPS`, `MAX_LR`, `WEIGHT_DECAY`: Training hyperparameters.
+
+To run the training using this script:
+```bash
+chmod +x train_alpaca.sh
+./train_alpaca.sh
+```
+
+Alternatively, you can run `train.py` directly and specify the dataset type and path:
+```bash
+# Example for single GPU/CPU using alpaca_sample.json
+python train.py --dataset_type alpaca --dataset_path alpaca_sample.json --batch_size 2 --seq_len 64 --max_steps 20
+
+# Example for DDP with 2 GPUs
+torchrun --nproc_per_node=2 train.py --dataset_type alpaca --dataset_path your_dataset.jsonl --batch_size <your_batch_size> --seq_len <your_seq_len>
+```
+Refer to `python train.py --help` for all available command-line options.
 
 ## Future Work and Improvements
 - Train on a larger dataset with more compute. (Dataset we can use is the LLM cleaned [Huggingface Fineweb 10B Token](https://huggingface.co/datasets/HuggingFaceFW/fineweb-edu) but i dont have the compute to train it :(  )

--- a/alpaca_sample.json
+++ b/alpaca_sample.json
@@ -1,0 +1,27 @@
+[
+    {
+        "instruction": "What is the capital of France?",
+        "input": "",
+        "output": "The capital of France is Paris."
+    },
+    {
+        "instruction": "Write a short story about a robot who learns to paint.",
+        "input": "The robot's name is Unit 734.",
+        "output": "Unit 734 had always processed logic, never art. One day, it found a discarded set of paints. Curious, it dabbed a brush into a vibrant blue, and a new world of expression opened up. Its circuits hummed with a novel kind of joy as it created its first, clumsy masterpiece."
+    },
+    {
+        "instruction": "Explain the theory of relativity in simple terms.",
+        "input": "",
+        "output": "Einstein's theory of relativity basically says two main things. First, the laws of physics are the same for everyone, no matter how fast they are moving, as long as they're not accelerating. Second, the speed of light is constant for everyone. These ideas lead to some pretty wild consequences, like time slowing down for things moving very fast!"
+    },
+    {
+        "instruction": "List three benefits of regular exercise.",
+        "input": "",
+        "output": "Three benefits of regular exercise are: 1. Improved physical health, such as a stronger heart and better weight management. 2. Enhanced mental well-being, including reduced stress and symptoms of depression. 3. Increased energy levels and better sleep quality."
+    },
+    {
+        "instruction": "Translate 'hello world' to Spanish.",
+        "input": "",
+        "output": "Hola Mundo"
+    }
+]

--- a/model.py
+++ b/model.py
@@ -174,3 +174,123 @@ class DataLoaderDDP:
             self.current_position = self.B * self.T * self.process_rank
 
         return x , y
+
+import json
+
+class AlpacaDataLoader:
+    def __init__(self, B, T, process_rank, num_processes, dataset_path):
+        self.B = B
+        self.T = T
+        self.process_rank = process_rank
+        self.num_processes = num_processes
+        self.dataset_path = dataset_path
+
+        enc = tiktoken.get_encoding("gpt2")
+
+        self.data = []
+        try:
+            with open(self.dataset_path, 'r') as f:
+                # Attempt to load as JSONL first
+                for line in f:
+                    try:
+                        self.data.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        # If JSONL fails, reset and try to load as a single JSON array
+                        f.seek(0)
+                        self.data = json.load(f)
+                        break # Loaded as single JSON, no need to iterate lines further
+        except Exception as e:
+            print(f"Error loading or parsing dataset file: {self.dataset_path}. Error: {e}")
+            self.tokens = torch.tensor([], dtype=torch.long)
+            self.current_position = 0
+            self.start_idx = 0
+            self.end_idx = 0
+            return
+
+        formatted_texts = []
+        for item in self.data:
+            instruction = item.get('instruction', '')
+            output = item.get('output', '')
+            input_text = item.get('input', '') # Alpaca format often includes an 'input' field
+            if input_text:
+                formatted_text = f"Instruction: {instruction}\nInput: {input_text}\nOutput: {output}"
+            else:
+                formatted_text = f"Instruction: {instruction}\nOutput: {output}"
+            # Add EOS token to signify end of a sequence pair for the model
+            formatted_texts.append(formatted_text + enc.eos_token)
+
+        tokens_list = []
+        for text in formatted_texts:
+            tokens_list.extend(enc.encode(text))
+
+        self.tokens = torch.tensor(tokens_list, dtype=torch.long)
+
+        if len(self.tokens) == 0:
+            print(f"No tokens loaded from {self.dataset_path}. Please check the dataset format and content.")
+            self.current_position = 0
+            self.start_idx = 0
+            self.end_idx = 0
+            return
+
+        print(f'loaded {len(self.tokens)} tokens from {self.dataset_path}')
+
+        # Distribute tokens among processes for DDP
+        # Each process gets a chunk of the total tokens
+        num_tokens_total = len(self.tokens)
+        tokens_per_process = num_tokens_total // self.num_processes
+        self.start_idx = self.process_rank * tokens_per_process
+        self.end_idx = (self.process_rank + 1) * tokens_per_process
+        if self.process_rank == self.num_processes - 1:
+            self.end_idx = num_tokens_total # Last process takes any remainder
+
+        self.current_position = self.start_idx
+        # Calculate effective tokens for this process
+        effective_tokens_this_process = self.end_idx - self.start_idx
+        if effective_tokens_this_process < B * T +1 and effective_tokens_this_process > 0:
+            print(f"Warning: Process {self.process_rank} has only {effective_tokens_this_process} tokens, which is less than B*T+1 = {B*T+1}. This process might not be able to produce full batches.")
+        elif effective_tokens_this_process == 0 and num_tokens_total > 0 : # Only print if there were tokens to begin with
+             print(f"Warning: Process {self.process_rank} has no tokens assigned. This might happen if the dataset is too small for the number of processes.")
+
+
+        if effective_tokens_this_process > 0 : # Only print if this process has tokens
+            print(f'Process {self.process_rank}: assigned tokens from {self.start_idx} to {self.end_idx} ({effective_tokens_this_process} tokens)')
+            # Corrected calculation for batches per epoch for this process
+            batches_this_process = effective_tokens_this_process // (B * T)
+            print(f'Process {self.process_rank}: 1 epoch = {batches_this_process} batches')
+        else:
+            print(f'Process {self.process_rank}: No tokens assigned.')
+
+    def get_batch(self):
+        # Check if this process has any tokens assigned at all or if tokens failed to load
+        if self.start_idx >= self.end_idx or len(self.tokens) == 0:
+            return None, None
+
+        required_tokens_for_batch = self.B * self.T + 1
+
+        if self.current_position + required_tokens_for_batch > self.end_idx:
+            self.current_position = self.start_idx # Reset for next epoch for this process
+
+        if self.current_position + required_tokens_for_batch > self.end_idx:
+            # Not enough tokens for a full batch even after reset (chunk too small for this process)
+            return None, None
+
+        buf = self.tokens[self.current_position : self.current_position + required_tokens_for_batch]
+
+        x = buf[:-1].view(self.B, self.T)
+        y = buf[1:].view(self.B, self.T)
+
+        self.current_position += self.B * self.T
+
+        return x, y
+
+# Ensure the new class is available for import if model.py is imported elsewhere.
+# (Assuming other classes like GPT, ModelConf etc. are defined above)
+# Check if __all__ is already defined, if so, append to it, otherwise create it.
+try:
+    # This will raise NameError if __all__ is not defined, which is fine.
+    if 'AlpacaDataLoader' not in __all__:
+        __all__.append('AlpacaDataLoader')
+except NameError:
+    # __all__ was not defined, so define it including all relevant classes from model.py
+    # Assuming these are the main classes to be exported. Adjust if others are needed.
+    __all__ = ['ModelConf', 'GPT', 'SelfAttention', 'MLP', 'Block', 'DataLoaderDDP', 'AlpacaDataLoader']

--- a/model.py
+++ b/model.py
@@ -217,11 +217,12 @@ class AlpacaDataLoader:
             else:
                 formatted_text = f"Instruction: {instruction}\nOutput: {output}"
             # Add EOS token to signify end of a sequence pair for the model
-            formatted_texts.append(formatted_text + enc.eos_token)
+            # For GPT-2, the EOS token ID is 50256 (end-of-text token)
+            formatted_texts.append(formatted_text + "<|endoftext|>")
 
         tokens_list = []
         for text in formatted_texts:
-            tokens_list.extend(enc.encode(text))
+            tokens_list.extend(enc.encode(text, allowed_special={'<|endoftext|>'}))
 
         self.tokens = torch.tensor(tokens_list, dtype=torch.long)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+torch>=2.0.0
+tiktoken>=0.4.0 

--- a/train.py
+++ b/train.py
@@ -1,140 +1,192 @@
-from model import DataLoaderDDP, GPT, ModelConf
+from model import GPT, ModelConf, DataLoaderDDP, AlpacaDataLoader # Added AlpacaDataLoader
 import time
 import os
 import torch
-import torch.nn as nn
-from torch.nn import functional as F
+import torch.nn as nn # Not strictly used in this script but often kept
+from torch.nn import functional as F # Used for cross_entropy
 import math
 from torch.nn.parallel import DistributedDataParallel as DDP
 import torch.distributed as dist
 from torch.distributed import init_process_group, destroy_process_group
+import argparse # Added argparse
 
-# we are going to implement cosine decay with warmup
+# --- Argument Parsing ---
+parser = argparse.ArgumentParser(description='Train a GPT model.')
+parser.add_argument('--dataset_path', type=str, default='input.txt',
+                    help='Path to the dataset file. Default: input.txt')
+parser.add_argument('--dataset_type', type=str, default='text', choices=['text', 'alpaca'],
+                    help="Type of dataset: 'text' for plain text, 'alpaca' for Alpaca-style JSON/JSONL. Default: text")
+# Add other existing or new training parameters here if needed, e.g.:
+parser.add_argument('--batch_size', type=int, default=4, help='Micro-batch size per process.') # B
+parser.add_argument('--seq_len', type=int, default=32, help='Sequence length.') # T
+parser.add_argument('--max_steps', type=int, default=50, help='Maximum training steps.')
+parser.add_argument('--warmup_steps', type=int, default=10, help='Warmup steps for learning rate scheduler.')
+parser.add_argument('--max_lr', type=float, default=3e-4, help='Maximum learning rate.')
+parser.add_argument('--weight_decay', type=float, default=0.1, help='Weight decay for optimizer.')
+
+args = parser.parse_args()
+
+# --- Learning Rate Scheduler --- (using args)
 def learning_rate_scheduler(i):
-    if i < warmup_steps:
-        return max_lr * (i + 1) / warmup_steps
-    if i > max_steps:
-        return min_lr
-    decay_ratio = (i - warmup_steps) / (max_steps - warmup_steps)
+    # Adjusted to use args for max_lr, warmup_steps, max_steps
+    effective_max_lr = args.max_lr
+    effective_min_lr = effective_max_lr * 0.1 # min_lr is 10% of max_lr
+    if i < args.warmup_steps:
+        return effective_max_lr * (i + 1) / args.warmup_steps
+    if i > args.max_steps:
+        return effective_min_lr
+    decay_ratio = (i - args.warmup_steps) / (args.max_steps - args.warmup_steps)
     assert 0 <= decay_ratio <= 1
     coeff = 0.5 * (1.0 + math.cos(math.pi * decay_ratio))
-    return min_lr + coeff * (max_lr - min_lr)
+    return effective_min_lr + coeff * (effective_max_lr - effective_min_lr)
 
-# setting up distributed data parallel training
+# --- DDP Setup --- (remains the same)
 
-# torchrun command will now set upu the env variables Rank, Local_rank and world_size
-ddp = int(os.environ.get('RANK', -1)) != -1  # check if we ae running in distributed mode
-
+ddp = int(os.environ.get('RANK', -1)) != -1
 if ddp:
-    assert torch.cuda.is_available(), "LMAO youre GPU poor"
+    assert torch.cuda.is_available(), "DDP requires CUDA"
     init_process_group(backend="nccl")
     ddp_rank = int(os.environ["RANK"])
     ddp_local_rank = int(os.environ["LOCAL_RANK"])
     ddp_world_size = int(os.environ["WORLD_SIZE"])
     device = f"cuda:{ddp_local_rank}"
     torch.cuda.set_device(device)
-    master_process = ddp_rank == 0  # Main Process : This process will do logging, checkpointing, etc.
+    master_process = ddp_rank == 0
 else:
-    # Poor people shit bro
     ddp_rank = 0
     ddp_local_rank = 0
     ddp_world_size = 1
     master_process = True
-
     device = "cpu"
     if torch.cuda.is_available():
         device = "cuda"
     elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
         device = "mps"
+    if master_process: # Ensure print only happens once for non-DDP too
+        print(f"Using device: {device}")
 
-    print("Using device: ", device)
-
-# for reusability
 torch.manual_seed(1337)
 if torch.cuda.is_available():
     torch.cuda.manual_seed(1337)
 
-# could have added the 0.5M total_batchsize to replicate the paper but we dont have enough hardware to implement gradient accumulation by using microbatches and not update the gradient just add them and keep for after all microbatches done
-total_batch_size = 524288
-B = 4  # this is the microbatch size now
-T = 32
-assert total_batch_size % (B * T) == 0, "make sure batch size is divisible by B and T "
-grad_accum_steps = total_batch_size // (B * T * ddp_world_size)  # each process will do B* T 
+# --- Batch and Gradient Accumulation Setup --- (using args for B and T)
+# Paper used 0.5M tokens total_batch_size. We use a smaller one.
+total_batch_size = 524288 # Kept fixed as per original script, could be an arg
+B = args.batch_size
+T = args.seq_len
+
+assert total_batch_size % (B * T * ddp_world_size) == 0, f"Total batch size {total_batch_size} must be divisible by B * T * ddp_world_size ({B} * {T} * {ddp_world_size})"
+grad_accum_steps = total_batch_size // (B * T * ddp_world_size)
+
 if master_process:
-    print(f"total desired batch size : {total_batch_size}")
-    print(f"calcaulated gradient accumumlation steps : {grad_accum_steps}")
+    print(f"Total desired batch size: {total_batch_size}")
+    print(f"Micro-batch size B: {B}, Sequence Length T: {T}")
+    print(f"Calculated gradient accumulation steps per process: {grad_accum_steps}")
+    print(f"Dataset type: {args.dataset_type}, Path: {args.dataset_path}")
 
-train_loader = DataLoaderDDP(B=B, T=T, process_rank=ddp_rank, num_processes=ddp_world_size)
-# 4, 1024 was working with 10 seconds per step
-torch.set_float32_matmul_precision("high")  # tensor float 32 TF32
+# --- Data Loader --- (Conditional instantiation)
+if args.dataset_type == 'alpaca':
+    train_loader = AlpacaDataLoader(B=B, T=T, process_rank=ddp_rank, num_processes=ddp_world_size, dataset_path=args.dataset_path)
+else: # default 'text'
+    # DataLoaderDDP uses 'input.txt' hardcoded, or if it's adapted to take a path:
+    # train_loader = DataLoaderDDP(B=B, T=T, process_rank=ddp_rank, num_processes=ddp_world_size, file_path=args.dataset_path)
+    # For now, stick to current DataLoaderDDP behavior for 'text' type
+    if args.dataset_path != 'input.txt' and master_process:
+        print(f"Warning: dataset_type is 'text', but dataset_path is '{args.dataset_path}'. DataLoaderDDP uses 'input.txt' by default.")
+    train_loader = DataLoaderDDP(B=B, T=T, process_rank=ddp_rank, num_processes=ddp_world_size)
 
-# automated mixed precision for faster training and reducing the precision of the tensor representation
-# adding this because torch.compile is not supported on mps devices
-import torch._dynamo
-torch._dynamo.config.suppress_errors = True
+torch.set_float32_matmul_precision("high")
 
-print(f'Initialising the model')
-model = GPT(ModelConf(vocab_size=50304))  # making it a nicer power of 2 so we can optimise gpu space block tiles
-model.eval()
+import torch._dynamo # Only if using torch.compile and not on MPS
+if device != "mps":
+    torch._dynamo.config.suppress_errors = True # Suppress errors for torch.compile
+
+if master_process:
+    print(f'Initialising the model')
+# ModelConf vocab_size 50304 is slightly > GPT-2's 50257. This is fine.
+# It allows for potential addition of special tokens if needed, and is a power of 2 multiple for efficiency.
+model = GPT(ModelConf(vocab_size=50304))
 model.to(device)
-model = torch.compile(model)
+if device != "mps": # torch.compile not fully supported on MPS for all models
+    model = torch.compile(model)
 
 if ddp:
     model = DDP(model, device_ids=[ddp_local_rank])
+raw_model = model.module if ddp else model
 
-raw_model = model.module if ddp else model  # always contains the raw model
+# Optimizer (using args for lr and weight_decay)
+optimizer = raw_model.configure_optimizers(weight_decay=args.weight_decay, learning_rate=args.max_lr, device_type=device)
 
-# loss, logits = model(x, y)
-max_lr = 3e-4
-min_lr = max_lr * 0.1
-warmup_steps = 10
-max_steps = 50
-
-optimizer = raw_model.configure_optimizers(weight_decay=0.1, learning_rate=6e-4, device_type=device)
-
-for step in range(max_steps):
+# Training loop (using args.max_steps)
+for step in range(args.max_steps):
     t0 = time.time()
     optimizer.zero_grad()
-    loss_acum = 0
+    loss_accum = 0.0 # Initialize as float
+    actual_micro_steps = 0 # Count micro_steps that successfully got a batch
+
     for micro_step in range(grad_accum_steps):
         x, y = train_loader.get_batch()
-        x, y = x.to(device), y.to(device)
-        with torch.autocast(device_type=device, dtype=torch.bfloat16):  # turn this on for cuda not suppported on mps
-            loss, logits = model(x, y)
-            # the 2 lines above cause this warning: WON'T CONVERT forward <ipython-input-3-e1e81a0fd956> line 112  due to: Traceback (most recent call last):File "/usr/local/lib/python3.10/dist-packages/torch/_dynamo/convert_frame.py", line 786, in _convert_frame
-        loss = loss / grad_accum_steps  # normalizing the losses for all the microsteps
-        loss_acum += loss.detach()  # accumulating the loss for printing
 
-        # not using a sync context manager for sync here
-        if ddp:
-            # this is used to only sync the gradients at the last step of the ddp
-            if micro_step == grad_accum_steps - 1:
-                model.require_backward_grad_sync = True
-            else:
-                model.require_backward_grad_sync = False
+        if x is None or y is None: # Handle case where a process might not get a batch
+            if ddp_world_size > 1 and master_process and micro_step == 0 and step % 10 ==0: # Print occasionally for DDP
+                 print(f"Rank {ddp_rank} did not receive a batch for micro_step {micro_step} in step {step}. Skipping this micro_step for this rank.")
+            elif ddp_world_size == 1 and master_process and micro_step == 0 and step % 10 == 0: # Print for single process
+                 print(f"Did not receive a batch for micro_step {micro_step} in step {step}. Might be end of data or small dataset.")
+            continue # Skip this micro-step if no data
+
+        actual_micro_steps +=1
+        x, y = x.to(device), y.to(device)
+
+        # Automated Mixed Precision (AMP)
+        # Use torch.bfloat16 if cuda and available, else float32 for CPU/MPS
+        pt_dtype = torch.bfloat16 if device == 'cuda' and torch.cuda.is_bf16_supported() else torch.float32
+        with torch.autocast(device_type=device, dtype=pt_dtype):
+            loss, logits = model(x, y)
         
+        loss = loss / grad_accum_steps # Normalize loss for accumulation
+        loss_accum += loss.detach()
+
+        if ddp:
+            # Sync gradients only at the last micro-step of accumulation
+            model.require_backward_grad_sync = (micro_step == grad_accum_steps - 1)
         loss.backward()
-    # avg the loss across all processes
+
+    if actual_micro_steps == 0 and master_process:
+        print(f"Step {step}: No batches processed across all micro_steps. Ending training or check dataset.")
+        break # If no data was processed in any micro_step, break training loop
+
     if ddp:
-        dist.all_reduce(loss_acum, op=dist.ReduceOp.AVG)
-    # clip the gradients to norm 
-    norm = torch.nn.utils.clip_grad_norm(model.parameters(), 1.0)  # normalising for not shocking the model in terms of the gradient movement, this can be caused by bad data batches
+        dist.all_reduce(loss_accum, op=dist.ReduceOp.AVG)
+
+    norm = torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+
     lr = learning_rate_scheduler(step)
     for param_group in optimizer.param_groups:
         param_group['lr'] = lr
 
     optimizer.step()
-    torch.cuda.synchronize()
-    t1 = time.time()
-    dt = (t1 - t0) * 1000
-    token_processed = train_loader.B * train_loader.T * grad_accum_steps * ddp_world_size
-    tokens_per_second = token_processed / (t1 - t0)
-    if master_process:
-        print(f"Step {step} | Loss {loss_acum.item()}, | time : {dt:.2f}ms  | tokens/s: {tokens_per_second}")
 
-# kill processes
+    if device == 'cuda':
+        torch.cuda.synchronize()
+
+    t1 = time.time()
+    dt = (t1 - t0) * 1000 # time in ms
+    # Tokens processed in this step (B * T per micro_step * actual_micro_steps_done_by_this_process * world_size)
+    # Note: train_loader.B and train_loader.T are used, which are args.batch_size and args.seq_len
+    tokens_processed_this_step = args.batch_size * args.seq_len * actual_micro_steps * ddp_world_size
+    tokens_per_second = tokens_processed_this_step / (t1 - t0) if (t1-t0) > 0 else 0
+
+    if master_process:
+        print(f"Step {step:4d} | Loss {loss_accum.item():.6f} | LR {lr:.4e} | Norm {norm:.4f} | Time {dt:.2f}ms | Tokens/s {tokens_per_second:.0f}")
+
 if ddp:
     destroy_process_group()
 
-print(f'this is the shape of the logits : {logits.shape}')
-print(loss)
+# The final print statements for logits and loss might be less meaningful after many steps
+# or if the last batch was partial/skipped, but kept for consistency with original script.
+if master_process and 'logits' in locals(): # Check if logits was defined (i.e., at least one batch processed)
+    print(f'Last batch logits shape: {logits.shape}')
+    print(f'Last accumulated loss: {loss_accum.item() if isinstance(loss_accum, torch.Tensor) else loss_accum}')
+else:
+    if master_process:
+        print("Training finished, possibly without processing any batches in the last step or overall.")

--- a/train_alpaca.sh
+++ b/train_alpaca.sh
@@ -22,9 +22,9 @@ WEIGHT_DECAY=0.01
 # The script uses torchrun for DDP if NPROC_PER_NODE > 1,
 # or runs directly if NPROC_PER_NODE is 1.
 
-CMD="python train.py"
-CMD+=" --dataset_path '$DATASET_PATH'"
-CMD+=" --dataset_type '$DATASET_TYPE'"
+CMD="python3 train.py"
+CMD+=" --dataset_path $DATASET_PATH"
+CMD+=" --dataset_type $DATASET_TYPE"
 CMD+=" --batch_size $BATCH_SIZE"
 CMD+=" --seq_len $SEQ_LEN"
 CMD+=" --max_steps $MAX_STEPS"

--- a/train_alpaca.sh
+++ b/train_alpaca.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Script to train the GPT model with an Alpaca-style dataset
+
+# --- Configuration --- #
+# DDP settings (adjust NPROC_PER_NODE as needed)
+NPROC_PER_NODE=1 # Number of GPUs to use. Set to 1 for single GPU/CPU training.
+MASTER_ADDR='localhost'
+MASTER_PORT='29500' # You can change this port if needed
+
+# Training script parameters (adjust as needed)
+DATASET_PATH="alpaca_sample.json" # Path to your Alpaca JSON/JSONL dataset
+DATASET_TYPE="alpaca"
+BATCH_SIZE=2 # Micro-batch size per process (adjust based on your GPU memory)
+SEQ_LEN=64   # Sequence length (adjust based on your GPU memory and dataset)
+MAX_STEPS=20 # Maximum training steps (adjust for a full training run)
+WARMUP_STEPS=5 # Warmup steps
+MAX_LR=3e-5    # Maximum learning rate (can be smaller for fine-tuning)
+WEIGHT_DECAY=0.01
+
+# --- Run Training --- #
+# The script uses torchrun for DDP if NPROC_PER_NODE > 1,
+# or runs directly if NPROC_PER_NODE is 1.
+
+CMD="python train.py"
+CMD+=" --dataset_path '$DATASET_PATH'"
+CMD+=" --dataset_type '$DATASET_TYPE'"
+CMD+=" --batch_size $BATCH_SIZE"
+CMD+=" --seq_len $SEQ_LEN"
+CMD+=" --max_steps $MAX_STEPS"
+CMD+=" --warmup_steps $WARMUP_STEPS"
+CMD+=" --max_lr $MAX_LR"
+CMD+=" --weight_decay $WEIGHT_DECAY"
+
+# Add any other parameters from train.py's argparse here
+# For example:
+# CMD+=" --some_other_param_from_train_py <value>"
+
+if [ "$NPROC_PER_NODE" -gt 1 ]; then
+  echo "Starting DDP training with $NPROC_PER_NODE processes."
+  # Ensure WORLD_SIZE is set if not using torchrun's auto-assignment with nnodes > 1, though for single node it's NPROC_PER_NODE
+  # For single-node DDP, torchrun handles RANK, LOCAL_RANK, WORLD_SIZE.
+  torchrun --nproc_per_node=$NPROC_PER_NODE --master_addr=$MASTER_ADDR --master_port=$MASTER_PORT $CMD
+else
+  echo "Starting single-process training."
+  # For single process, DDP environment variables are not strictly needed by train.py's DDP setup if ddp=False.
+  # However, if train.py expects them, they might need to be set (e.g. RANK=0, WORLD_SIZE=1, LOCAL_RANK=0)
+  # The current train.py handles the ddp=False case correctly without these being explicitly set for single process.
+  $CMD
+fi
+
+echo "Training script finished."


### PR DESCRIPTION
This commit introduces the capability to train the GPT model on Alpaca-style conversational datasets.

Key changes include:

- Added `AlpacaDataLoader` to `model.py`: This new data loader can process JSON/JSONL files containing instruction-response pairs, tokenizes them, and prepares batches suitable for DDP training. It handles formatting of instruction, optional input, and output fields, and appends EOS tokens.
- Updated `train.py`:
    - Integrated `AlpacaDataLoader`.
    - Added command-line arguments (`--dataset_path`, `--dataset_type`, and others for training hyperparameters) for better configurability.
    - Implemented conditional logic to use the appropriate data loader based on `dataset_type`.
    - Improved handling of batches when processes might run out of data.
- Created `alpaca_sample.json`: A sample Alpaca-style dataset for testing and demonstration.
- Created `train_alpaca.sh`: A shell script to provide a singular command for initiating training with Alpaca-style datasets, with configurable DDP and training parameters.
- Updated `README.md`: Documented the new feature, dataset format requirements, and usage instructions for both the shell script and direct `train.py` execution.

I initiated testing of the `train_alpaca.sh` script. However, I could not fully complete it due to insufficient disk space in the execution environment, which prevented the installation of PyTorch. The implemented code changes are complete based on the plan.